### PR TITLE
Export and fix settings for `AuroraHighRes`

### DIFF
--- a/aurora/__init__.py
+++ b/aurora/__init__.py
@@ -1,11 +1,12 @@
 """Copyright (c) Microsoft Corporation. Licensed under the MIT license."""
 
 from aurora.batch import Batch, Metadata
-from aurora.model.aurora import Aurora, AuroraSmall
+from aurora.model.aurora import Aurora, AuroraHighRes, AuroraSmall
 from aurora.rollout import rollout
 
 __all__ = [
     "Aurora",
+    "AuroraHighRes",
     "AuroraSmall",
     "Batch",
     "Metadata",

--- a/aurora/model/aurora.py
+++ b/aurora/model/aurora.py
@@ -253,6 +253,7 @@ AuroraSmall = partial(
 
 AuroraHighRes = partial(
     Aurora,
+    patch_size=10,
     encoder_depths=(6, 8, 8),
     decoder_depths=(8, 8, 6),
 )


### PR DESCRIPTION
`AuroraHighRes` was exported and the patch size was configured incorrectly. 

Fixes #18 