### PR TITLE
Implement adjustment for the normalisation of surface-level variables

### DIFF
--- a/aurora/batch.py
+++ b/aurora/batch.py
@@ -72,11 +72,23 @@ class Batch:
         """Get the spatial shape from an arbitrary surface-level variable."""
         return next(iter(self.surf_vars.values())).shape[-2:]
 
-    def normalise(self) -> "Batch":
-        """Normalise all variables in the batch."""
+    def normalise(self, surf_stats: dict[str, tuple[float, float]]) -> "Batch":
+        """Normalise all variables in the batch.
+
+        Args:
+            surf_stats (dict[str, tuple[float, float]]): For these surface-level variables, adjust
+                the normalisation to the given tuple consisting of a new location and scale.
+
+        Returns:
+            :class:`.Batch`: Normalised batch.
+        """
         return Batch(
-            surf_vars={k: normalise_surf_var(v, k) for k, v in self.surf_vars.items()},
-            static_vars={k: normalise_surf_var(v, k) for k, v in self.static_vars.items()},
+            surf_vars={
+                k: normalise_surf_var(v, k, stats=surf_stats) for k, v in self.surf_vars.items()
+            },
+            static_vars={
+                k: normalise_surf_var(v, k, stats=surf_stats) for k, v in self.static_vars.items()
+            },
             atmos_vars={
                 k: normalise_atmos_var(v, k, self.metadata.atmos_levels)
                 for k, v in self.atmos_vars.items()
@@ -84,11 +96,23 @@ class Batch:
             metadata=self.metadata,
         )
 
-    def unnormalise(self) -> "Batch":
-        """Unnormalise all variables in the batch."""
+    def unnormalise(self, surf_stats: dict[str, tuple[float, float]]) -> "Batch":
+        """Unnormalise all variables in the batch.
+
+        Args:
+            surf_stats (dict[str, tuple[float, float]]): For these surface-level variables, adjust
+                the normalisation to the given tuple consisting of a new location and scale.
+
+        Returns:
+            :class:`.Batch`: Unnormalised batch.
+        """
         return Batch(
-            surf_vars={k: unnormalise_surf_var(v, k) for k, v in self.surf_vars.items()},
-            static_vars={k: unnormalise_surf_var(v, k) for k, v in self.static_vars.items()},
+            surf_vars={
+                k: unnormalise_surf_var(v, k, stats=surf_stats) for k, v in self.surf_vars.items()
+            },
+            static_vars={
+                k: unnormalise_surf_var(v, k, stats=surf_stats) for k, v in self.static_vars.items()
+            },
             atmos_vars={
                 k: unnormalise_atmos_var(v, k, self.metadata.atmos_levels)
                 for k, v in self.atmos_vars.items()

--- a/aurora/normalisation.py
+++ b/aurora/normalisation.py
@@ -1,6 +1,7 @@
 """Copyright (c) Microsoft Corporation. Licensed under the MIT license."""
 
 from functools import partial
+from typing import Optional
 
 import torch
 
@@ -15,11 +16,15 @@ __all__ = [
 def normalise_surf_var(
     x: torch.Tensor,
     name: str,
+    stats: Optional[dict[str, tuple[float, float]]] = None,
     unnormalise: bool = False,
 ) -> torch.Tensor:
     """Normalise a surface-level variable."""
-    location = locations[name]
-    scale = scales[name]
+    if stats and name in stats:
+        location, scale = stats[name]
+    else:
+        location = locations[name]
+        scale = scales[name]
     if unnormalise:
         return x * scale + location
     else:

--- a/docs/models.md
+++ b/docs/models.md
@@ -158,11 +158,21 @@ For optimal performance, the model requires the following variables and pressure
 ### Static Variables
 
 Aurora 0.1° Fine-Tuned requires
-[static variables from IFS HRES analysis](https://rda.ucar.edu/datasets/ds113.1/).
-However, due to the way the model was trained,
-the model requires these variables to be scaled slightly differently.
-Therefore, you should use the static variables provided in
-[the HuggingFace repository](https://huggingface.co/microsoft/aurora/blob/main/aurora-0.1-static.pickle).
+[static variables from IFS HRES analysis](https://rda.ucar.edu/datasets/ds113.1/) regridded
+to 0.1° resolution.
+Because of differences between implementations of regridding methods, the resulting static
+variables might not be exactly equal to the ones we used during training.
+For this reason we also uploaded
+[the exact static variables which we used during training](https://huggingface.co/microsoft/aurora/blob/main/aurora-0.1-static.pickle).
+To use these, you must remove an exception to the normalisation by instantiating
+the model in the following way:
+
+```python
+from aurora import AuroraHighRes
+
+model = AuroraHighRes(surf_stats=None)  # Use static variables from HF repo.
+model.load_checkpoint("microsoft/aurora", "aurora-0.1-finetuned.ckpt")
+```
 
 ### Notes
 


### PR DESCRIPTION
To be able to use the static variables from the NCAR archive, we must normalise one particular static variable in a different way. This PR implements that exception. Before merging, we should verify that the normalisation is right in the 0.1 degree example notebook (#9).