### PR TITLE
Fixed docs so the model loads correctly

### DIFF
--- a/docs/example_hres_t0.ipynb
+++ b/docs/example_hres_t0.ipynb
@@ -248,7 +248,7 @@
     "from aurora import Aurora, rollout\n",
     "\n",
     "model = Aurora()\n",
-    "model.load_checkpoint(\"wbruinsma/aurora\", \"aurora-0.25-finetuned.ckpt\")\n",
+    "model.load_checkpoint(\"microsoft/aurora\", \"aurora-0.25-finetuned.ckpt\")\n",
     "\n",
     "model.eval()\n",
     "model = model.to(\"cuda\")\n",


### PR DESCRIPTION
Hi everyone, 
The model in _Example: Predictions for HRES T0_ is referring to an old non public version. 

Best regards,
Lukas