### PR TITLE
Add information about `ai-models-aurora`

### DIFF
--- a/docs/_toc.yml
+++ b/docs/_toc.yml
@@ -8,4 +8,5 @@ chapters:
 - file: finetuning
 - file: example_era5
 - file: example_hres_t0
+- file: ai_models_plugin
 - file: api

--- a/docs/ai_models_plugin.md
+++ b/docs/ai_models_plugin.md
@@ -1,0 +1,18 @@
+# Plugin for ECMWF's `ai-models`
+
+Aurora is a supported model for ECMWF's
+[`ai-models`](https://github.com/ecmwf-lab/ai-models)
+through the plugin
+[`ai-models-aurora`](https://github.com/ecmwf-lab/ai-models-aurora).
+Install this plugin with `pip`:
+
+```bash
+pip install ai-models-aurora
+```
+
+See
+[the documentation of `ai-models`](https://github.com/ecmwf-lab/ai-models)
+for more information about `ai-models`
+and see
+[the documentation of `ai-models-aurora`](https://github.com/ecmwf-lab/ai-models-aurora)
+for more information about the Aurora plugin.


### PR DESCRIPTION
Adds a page that describes `ai-models-aurora`.

@b8raoult, is there any additional information that would be helpful to add here?

CC @mchantry