### PR TITLE
Update docs

### DIFF
--- a/docs/ai_models_plugin.md
+++ b/docs/ai_models_plugin.md
@@ -1,21 +1,17 @@
 # Plugin for ECMWF's `ai-models`
 
-```{warning}
-The plugin was intended to be released on PyPI under the name `ai-models-aurora`.
-Unfortunately, this name has been registered by a third party.
-Therefore, do _not_ install the plugin from the PyPI package name `ai-model-aurora`, but instead
-keep a close eye on the
-[the homepage of the plugin](https://github.com/ecmwf-lab/ai-models-aurora).
-```
-
 Aurora is a supported model for ECMWF's
 [`ai-models`](https://github.com/ecmwf-lab/ai-models)
 through
-[a plugin](https://github.com/ecmwf-lab/ai-models-aurora).
+[the plugin `ai-models-aurora`](https://github.com/ecmwf-lab/ai-models-aurora):
+
+```bash
+pip install ai-models-aurora
+```
 
 See
 [the documentation of `ai-models`](https://github.com/ecmwf-lab/ai-models)
 for more information about `ai-models`
 and see
 [the documentation of the plugin](https://github.com/ecmwf-lab/ai-models-aurora)
-for more information about the Aurora plugin.
+for more information about `ai-models-aurora`.


### PR DESCRIPTION
Update the docs in light that `ai-models-aurora` has been returned to ECMWF.

Closes #44 