### PR TITLE
Remove link to specific version on Foundry

### DIFF
--- a/docs/foundry/intro.md
+++ b/docs/foundry/intro.md
@@ -1,4 +1,4 @@
 # Aurora on Azure AI Foundry
 
-Aurora [is available as a model on Azure AI Foundry](https://ai.azure.com/explore/models/Aurora/version/2/registry/azureml)!
+Aurora [is available as a model on Azure AI Foundry](https://ai.azure.com/explore/models)!
 This part of the documentation describes how you can produce predictions with Aurora running on a Foundry endpoint.

--- a/docs/foundry/intro.md
+++ b/docs/foundry/intro.md
@@ -1,4 +1,4 @@
 # Aurora on Azure AI Foundry
 
-Aurora [is available as a model on Azure AI Foundry](https://ai.azure.com/explore/models/Aurora/version/1/registry/azureml)!
+Aurora [is available as a model on Azure AI Foundry](https://ai.azure.com/explore/models/Aurora/version/2/registry/azureml)!
 This part of the documentation describes how you can produce predictions with Aurora running on a Foundry endpoint.


### PR DESCRIPTION
What the title says. This way the link cannot get out of date.