### PR TITLE
Migrate to V2 Pydantic interface

### DIFF
--- a/aurora/foundry/server/mlflow_wrapper.py
+++ b/aurora/foundry/server/mlflow_wrapper.py
@@ -130,7 +130,7 @@ class AuroraModelWrapper(mlflow.pyfunc.PythonModel):
             logger.info("Creating a new task.")
             task = Task(Submission(**data["msg"]))
             self.TASKS[task.task_info.task_id] = task
-            return CreationResponse(task_id=task.task_info.task_id).dict()
+            return CreationResponse(task_id=task.task_info.task_id).model_dump()
 
         elif data["type"] == "task_info":
             logger.info("Processing an existing task.")
@@ -174,7 +174,7 @@ class AuroraModelWrapper(mlflow.pyfunc.PythonModel):
                         break
                     time.sleep(1)
 
-            return task.task_info.dict()
+            return task.task_info.model_dump()
 
         else:
             raise ValueError(f"Unknown data type: `{data['type']}`.")


### PR DESCRIPTION
## PR Summary
This small PR updates Pydantic method calls within the `AuroraModelWrapper` to align with the Pydantic V2 API and resolve `PydanticDeprecatedSince20` warnings. Changes:
- Replaced `instance.dict()` with `instance.model_dump()` in `aurora/foundry/server/mlflow_wrapper.py` for serializing `CreationResponse` and `task.task_info` objects to dictionaries.

These changes ensure compatibility with Pydantic V2+ and address deprecation warnings related to the `.dict()` method, as observed in [CI logs](https://github.com/microsoft/aurora/actions/runs/15438943636/job/43451894383#step:5:104).