### PR TITLE
Skip failing test on Windows

### DIFF
--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -72,6 +72,13 @@ def test_aurora_small(aurora_small: Aurora, test_input_output: tuple[Batch, Save
     assert pred.metadata.time == tuple(test_output["metadata"]["time"])
 
 
+@pytest.mark.skipif(
+    os.name == "nt",  # Checks if we're running on Windows.
+    reason=(
+        "DDP test suddenly started failing with error "
+        "`RuntimeError: makeDeviceForHostname(): unsupported gloo device` on Windows."
+    ),
+)
 def test_aurora_small_ddp(
     aurora_small: Aurora, test_input_output: tuple[Batch, SavedBatch]
 ) -> None:


### PR DESCRIPTION
This is causing CI to fail for e.g. #136.

Not quite sure why this is now suddenly happening.