### PR TITLE
Validate that `metadata.time` matches the batch size

### DIFF
--- a/aurora/batch.py
+++ b/aurora/batch.py
@@ -4,7 +4,7 @@ import dataclasses
 from datetime import datetime
 from functools import partial
 from pathlib import Path
-from typing import Callable, List
+from typing import Callable, Iterable, List
 
 import numpy as np
 import torch
@@ -87,33 +87,38 @@ class Batch:
     metadata: Metadata
 
     def __post_init__(self):
-        # All surface-level and atmospheric variables must agree on the batch dimension, and
-        # `metadata.time` must give exactly one time per batch element. The encoder relies on
-        # this when it adds the absolute time embedding, `(B, L, D) + (B, 1, D)`: if
-        # `len(metadata.time)` differs from `B`, that addition silently broadcasts the batch
-        # dimension to `len(metadata.time)`, and the failure only surfaces later as an
-        # `IndexError` in the decoder or, worse, as predictions of the wrong shape.
-        batch_sizes = {
-            v.shape[0]
-            for vs in (self.surf_vars, self.atmos_vars)
-            for v in vs.values()
-            if v.dim() > 0
-        }
-
-        if len(batch_sizes) > 1:
+        # The encoder adds the absolute time embedding as `(B, L, D) + (B, 1, D)` and the
+        # pressure encoding as `(B, C, L, D) + (1, len(atmos_levels), 1, D)`. In both cases, a
+        # length that disagrees with the data silently broadcasts rather than failing: the batch
+        # or level dimension is inflated to the length of the metadata, so the model happily
+        # returns predictions of the wrong shape. Check both up front instead.
+        batch_size = _consistent_size(
+            (*self.surf_vars.values(), *self.atmos_vars.values()),
+            dim=0,
+            what="batch size",
+            of_what="surface-level and atmospheric variables",
+        )
+        if batch_size is not None and len(self.metadata.time) != batch_size:
             raise ValueError(
-                "The surface-level and atmospheric variables must all have the same batch "
-                f"size, but found sizes {sorted(batch_sizes)}."
+                f"The number of times in the metadata ({len(self.metadata.time)}) must "
+                f"equal the batch size of the surface-level and atmospheric variables "
+                f"({batch_size})."
             )
 
-        if batch_sizes:
-            (batch_size,) = batch_sizes
-            if len(self.metadata.time) != batch_size:
-                raise ValueError(
-                    f"The number of times in the metadata ({len(self.metadata.time)}) must "
-                    f"equal the batch size of the surface-level and atmospheric variables "
-                    f"({batch_size})."
-                )
+        # The atmospheric variables are `(b, t, c, h, w)`, but the decoder briefly constructs a
+        # batch without the history dimension, so count the level dimension from the end.
+        level_size = _consistent_size(
+            self.atmos_vars.values(),
+            dim=-3,
+            what="number of pressure levels",
+            of_what="atmospheric variables",
+        )
+        if level_size is not None and len(self.metadata.atmos_levels) != level_size:
+            raise ValueError(
+                f"The number of pressure levels in the metadata "
+                f"({len(self.metadata.atmos_levels)}) must equal the number of pressure levels "
+                f"of the atmospheric variables ({level_size})."
+            )
 
     @property
     def spatial_shape(self) -> tuple[int, int]:
@@ -338,6 +343,31 @@ class Batch:
                 rollout_step=int(ds.rollout_step.values),
             ),
         )
+
+
+def _consistent_size(
+    tensors: Iterable[torch.Tensor],
+    dim: int,
+    what: str,
+    of_what: str,
+) -> int | None:
+    """Get the size of dimension `dim` of `tensors`, checking that they all agree.
+
+    Args:
+        tensors (iterable of :class:`torch.Tensor`): Tensors to check.
+        dim (int): Dimension to take the size of. May be negative, in which case it counts from
+            the end. Tensors with too few dimensions are skipped.
+        what (str): Description of the size, used in the error message.
+        of_what (str): Description of `tensors`, used in the error message.
+
+    Returns:
+        int or None: The common size, or `None` if no tensor has dimension `dim`.
+    """
+    min_dim = dim + 1 if dim >= 0 else -dim
+    sizes = {v.shape[dim] for v in tensors if v.dim() >= min_dim}
+    if len(sizes) > 1:
+        raise ValueError(f"The {of_what} must all have the same {what}, but found {sorted(sizes)}.")
+    return sizes.pop() if sizes else None
 
 
 def _np(x: torch.Tensor) -> np.ndarray:

--- a/aurora/batch.py
+++ b/aurora/batch.py
@@ -86,6 +86,35 @@ class Batch:
     atmos_vars: dict[str, torch.Tensor]
     metadata: Metadata
 
+    def __post_init__(self):
+        # All surface-level and atmospheric variables must agree on the batch dimension, and
+        # `metadata.time` must give exactly one time per batch element. The encoder relies on
+        # this when it adds the absolute time embedding, `(B, L, D) + (B, 1, D)`: if
+        # `len(metadata.time)` differs from `B`, that addition silently broadcasts the batch
+        # dimension to `len(metadata.time)`, and the failure only surfaces later as an
+        # `IndexError` in the decoder or, worse, as predictions of the wrong shape.
+        batch_sizes = {
+            v.shape[0]
+            for vs in (self.surf_vars, self.atmos_vars)
+            for v in vs.values()
+            if v.dim() > 0
+        }
+
+        if len(batch_sizes) > 1:
+            raise ValueError(
+                "The surface-level and atmospheric variables must all have the same batch "
+                f"size, but found sizes {sorted(batch_sizes)}."
+            )
+
+        if batch_sizes:
+            (batch_size,) = batch_sizes
+            if len(self.metadata.time) != batch_size:
+                raise ValueError(
+                    f"The number of times in the metadata ({len(self.metadata.time)}) must "
+                    f"equal the batch size of the surface-level and atmospheric variables "
+                    f"({batch_size})."
+                )
+
     @property
     def spatial_shape(self) -> tuple[int, int]:
         """Get the spatial shape from an arbitrary surface-level variable."""

--- a/tests/test_batch.py
+++ b/tests/test_batch.py
@@ -1,12 +1,16 @@
 """Copyright (c) Microsoft Corporation. Licensed under the MIT license."""
 
+import dataclasses
+from datetime import datetime
 from pathlib import Path
 
 import numpy as np
+import pytest
+import torch
 
 from tests.conftest import SavedBatch
 
-from aurora import Batch
+from aurora import Batch, Metadata
 
 
 def test_interpolation(test_input_output: tuple[Batch, SavedBatch]) -> None:
@@ -57,3 +61,45 @@ def test_save_load(test_input_output: tuple[Batch, SavedBatch], tmp_path: Path) 
     assert batch.metadata.time == batch_loaded.metadata.time
     assert batch.metadata.atmos_levels == batch_loaded.metadata.atmos_levels
     assert batch.metadata.rollout_step == batch_loaded.metadata.rollout_step
+
+
+def _batch(batch_size: int, n_times: int) -> Batch:
+    return Batch(
+        surf_vars={"2t": torch.randn(batch_size, 2, 17, 32)},
+        static_vars={"lsm": torch.randn(17, 32)},
+        atmos_vars={"z": torch.randn(batch_size, 2, 4, 17, 32)},
+        metadata=Metadata(
+            lat=torch.linspace(90, -90, 17),
+            lon=torch.linspace(0, 360, 33)[:-1],
+            time=tuple(datetime(2020, 6, 1, 12, 0) for _ in range(n_times)),
+            atmos_levels=(100, 250, 500, 850),
+        ),
+    )
+
+
+@pytest.mark.parametrize("batch_size", [1, 2, 3])
+def test_matching_times_and_batch_size(batch_size: int) -> None:
+    # One time per batch element is the documented contract, so this must be accepted.
+    assert len(_batch(batch_size, batch_size).metadata.time) == batch_size
+
+
+@pytest.mark.parametrize("batch_size, n_times", [(1, 2), (1, 100), (2, 1), (3, 2)])
+def test_mismatching_times_and_batch_size(batch_size: int, n_times: int) -> None:
+    # Without this check, the absolute time embedding in the encoder silently broadcasts the
+    # batch dimension to `len(metadata.time)`, which either fails much later with an obscure
+    # error or produces predictions of the wrong shape.
+    with pytest.raises(ValueError, match="number of times in the metadata"):
+        _batch(batch_size, n_times)
+
+
+def test_inconsistent_batch_sizes_between_variables() -> None:
+    batch = _batch(2, 2)
+    with pytest.raises(ValueError, match="same batch size"):
+        dataclasses.replace(batch, atmos_vars={"z": torch.randn(3, 2, 4, 17, 32)})
+
+
+def test_derived_batches_stay_valid(test_input_output: tuple[Batch, SavedBatch]) -> None:
+    # The operations that construct new batches must not trip the validation.
+    batch, _ = test_input_output
+    for derived in (batch.to("cpu"), batch.crop(4), batch.regrid(0.45)):
+        assert len(derived.metadata.time) == next(iter(derived.surf_vars.values())).shape[0]

--- a/tests/test_batch.py
+++ b/tests/test_batch.py
@@ -63,16 +63,25 @@ def test_save_load(test_input_output: tuple[Batch, SavedBatch], tmp_path: Path) 
     assert batch.metadata.rollout_step == batch_loaded.metadata.rollout_step
 
 
-def _batch(batch_size: int, n_times: int) -> Batch:
+_LEVELS = (100, 250, 500, 850)
+
+
+def _batch(
+    batch_size: int,
+    n_times: int,
+    n_levels: int = len(_LEVELS),
+    n_atmos_levels: int | None = None,
+) -> Batch:
+    n_atmos_levels = n_levels if n_atmos_levels is None else n_atmos_levels
     return Batch(
         surf_vars={"2t": torch.randn(batch_size, 2, 17, 32)},
         static_vars={"lsm": torch.randn(17, 32)},
-        atmos_vars={"z": torch.randn(batch_size, 2, 4, 17, 32)},
+        atmos_vars={"z": torch.randn(batch_size, 2, n_levels, 17, 32)},
         metadata=Metadata(
             lat=torch.linspace(90, -90, 17),
             lon=torch.linspace(0, 360, 33)[:-1],
             time=tuple(datetime(2020, 6, 1, 12, 0) for _ in range(n_times)),
-            atmos_levels=(100, 250, 500, 850),
+            atmos_levels=_LEVELS[:n_atmos_levels],
         ),
     )
 
@@ -98,8 +107,40 @@ def test_inconsistent_batch_sizes_between_variables() -> None:
         dataclasses.replace(batch, atmos_vars={"z": torch.randn(3, 2, 4, 17, 32)})
 
 
+@pytest.mark.parametrize("n_levels", [1, 2, 4])
+def test_matching_levels_and_atmos_levels(n_levels: int) -> None:
+    # One pressure level per level of the atmospheric variables is the documented contract.
+    batch = _batch(1, 1, n_levels=n_levels)
+    assert len(batch.metadata.atmos_levels) == n_levels
+
+
+@pytest.mark.parametrize("n_levels, n_atmos_levels", [(1, 4), (4, 1), (4, 2), (2, 4)])
+def test_mismatching_levels_and_atmos_levels(n_levels: int, n_atmos_levels: int) -> None:
+    # Without this check, the pressure encoding in the encoder silently broadcasts the level
+    # dimension to `len(metadata.atmos_levels)`: one level of data with four pressure levels
+    # returns four levels, three of them fabricated, and four levels of data with one pressure
+    # level silently discards three.
+    with pytest.raises(ValueError, match="number of pressure levels in the metadata"):
+        _batch(1, 1, n_levels=n_levels, n_atmos_levels=n_atmos_levels)
+
+
+def test_inconsistent_levels_between_atmos_variables() -> None:
+    batch = _batch(1, 1)
+    with pytest.raises(ValueError, match="same number of pressure levels"):
+        dataclasses.replace(
+            batch,
+            atmos_vars={
+                "z": torch.randn(1, 2, 4, 17, 32),
+                "t": torch.randn(1, 2, 3, 17, 32),
+            },
+        )
+
+
 def test_derived_batches_stay_valid(test_input_output: tuple[Batch, SavedBatch]) -> None:
     # The operations that construct new batches must not trip the validation.
     batch, _ = test_input_output
     for derived in (batch.to("cpu"), batch.crop(4), batch.regrid(0.45)):
         assert len(derived.metadata.time) == next(iter(derived.surf_vars.values())).shape[0]
+        assert (
+            len(derived.metadata.atmos_levels) == next(iter(derived.atmos_vars.values())).shape[-3]
+        )

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -27,11 +27,13 @@ def aurora_small() -> Aurora:
 def test_aurora_small(aurora_small: Aurora, test_input_output: tuple[Batch, SavedBatch]) -> None:
     batch, test_output = test_input_output
 
-    # Run the test with batch size two.
+    # Run the test with batch size two. `metadata.time` gives the time for every batch element,
+    # so it must be repeated along with the data.
     batch = dataclasses.replace(
         batch,
         surf_vars={k: v.repeat(2, 1, 1, 1) for k, v in batch.surf_vars.items()},
         atmos_vars={k: v.repeat(2, 1, 1, 1, 1) for k, v in batch.atmos_vars.items()},
+        metadata=dataclasses.replace(batch.metadata, time=batch.metadata.time * 2),
     )
     test_output = cast(SavedBatch, dict(test_output))  #  Copy before mutating.
     test_output["surf_vars"] = {k: v.repeat(2, axis=0) for k, v in test_output["surf_vars"].items()}


### PR DESCRIPTION
Fixes #188.

### What's changed since the issue was filed

The issue reports *silent* corruption on 1.8.0: the output batch dimension is inflated to
`len(metadata.time)` with no error. On current `main` the symptom is different —
`len(metadata.time) == 1` still works, and anything larger now fails with

```
IndexError: index 1 is out of bounds for dimension 0 with size 1
```

from `lead_times[i]` in `Perceiver3DDecoder.forward`. The root cause is unchanged: the encoder
still adds the absolute time embedding as

```python
x = x + absolute_time_embed.unsqueeze(1)  # (B, L, D) + (B, 1, D)
```

and that comment states an invariant which nothing enforces. So the failure has moved from
"quietly wrong" to "loud but misleading", and in the `len(metadata.time) < B` direction it is
still quietly wrong.

### The same bug on the pressure-level axis

While adding the check I looked for the same pattern elsewhere, and `Aurora3DEncoder.forward` has
it:

```python
atmos_levels_embed = self.atmos_levels_embed(atmos_levels_encode)[None, :, None, :]
x_atmos = x_atmos + atmos_levels_embed  # (B, C_A, L, D)
```

`x_atmos` is `(B, C, L, D)` and the encoding is `(1, len(atmos_levels), 1, D)`, so a disagreement
between `len(metadata.atmos_levels)` and the level dimension of the atmospheric variables
broadcasts exactly as the time embedding does. Running it on `AuroraSmall`:

| Input | Result on `main` |
| --- | --- |
| 1 level of data, 4 `atmos_levels` | runs, returns **4** pressure levels — three fabricated |
| 4 levels of data, 1 `atmos_level` | runs, returns **1** pressure level — three silently dropped |
| 4 levels of data, 2 `atmos_levels` | `RuntimeError` from the addition (loud, so fine) |

The two silent cases are the same class of bug as #188, so I've handled both here rather than
opening a near-identical second PR. Happy to split it out if you'd prefer to review them
separately.

### The fix

`Batch.__post_init__` now checks that

- all surface-level and atmospheric variables agree on the batch dimension,
- `metadata.time` gives exactly one time per batch element,
- all atmospheric variables agree on the pressure-level dimension, and
- `metadata.atmos_levels` gives exactly one level per level of those variables,

raising a `ValueError` at construction rather than deferring the failure. This matches the
documented contract — *"time: For every batch element, the time"* — and is consistent with the
existing latitude and longitude validation in `Metadata.__post_init__`. The two checks share a
small `_consistent_size` helper so the logic exists once.

One implementation note: the level dimension is counted from the end (`dim=-3`). `Perceiver3DDecoder`
constructs a `Batch` whose atmospheric variables are `(B, C, H, W)`, before `Aurora.forward` inserts
the history dimension, so a positive index would read the height as a level count there.

### One test needed changing, and it's worth flagging

`test_aurora_small` duplicates the data to batch size two but leaves `metadata.time` at length
one:

```python
batch = dataclasses.replace(
    batch,
    surf_vars={k: v.repeat(2, 1, 1, 1) for k, v in batch.surf_vars.items()},
    atmos_vars={k: v.repeat(2, 1, 1, 1, 1) for k, v in batch.atmos_vars.items()},
)
```

It passes on `main` because the broadcast happens to do the right thing in that direction, but
it does contradict the documented contract. I've repeated the time along with the data. Happy to
take a different approach if you'd rather the `len(metadata.time) == 1` case stay supported as an
explicit broadcast — that would be a small change to the check.

### Tests

Added to `tests/test_batch.py`:

- matching times and batch size is accepted, for batch sizes 1, 2 and 3;
- time mismatches raise, covering both directions — `(B=1, times=2)`, `(B=1, times=100)`,
  `(B=2, times=1)`, `(B=3, times=2)`;
- variables disagreeing with each other on the batch dimension raise;
- matching levels and `atmos_levels` is accepted, for 1, 2 and 4 levels;
- level mismatches raise, again both directions — `(C=1, levels=4)`, `(C=4, levels=1)`,
  `(C=4, levels=2)`, `(C=2, levels=4)`;
- atmospheric variables disagreeing with each other on the level dimension raise;
- `to`, `crop` and `regrid` still produce valid batches.

`tests/test_batch.py` and `tests/test_headers.py` pass (73 tests). The full suite is
`117 passed, 1 failed`, the failure being the pre-existing `test_aurora_small` described below.
`ruff check` and `ruff format --check` are clean.

### Note on `test_aurora_small`

It fails for me at `0.04224444 / 276.22`, marginally over the `1e-4` tolerance. This is
pre-existing and unrelated: I get the **identical** value on unmodified `main`, and it looks like
the machine-dependent numerics discussed in #169. Flagging it so it isn't mistaken for a
regression here.
