### PR TITLE
Validate the grid, the history dimension and the latitudes and longitudes

### DIFF
--- a/aurora/batch.py
+++ b/aurora/batch.py
@@ -4,7 +4,7 @@ import dataclasses
 from datetime import datetime
 from functools import partial
 from pathlib import Path
-from typing import Callable, List
+from typing import Callable, Iterable, List
 
 import numpy as np
 import torch
@@ -85,6 +85,52 @@ class Batch:
     static_vars: dict[str, torch.Tensor]
     atmos_vars: dict[str, torch.Tensor]
     metadata: Metadata
+
+    def __post_init__(self):
+        surf = tuple(self.surf_vars.values())
+        static = tuple(self.static_vars.values())
+        atmos = tuple(self.atmos_vars.values())
+
+        # Every variable must describe the same grid. Compare the last two dimensions rather than
+        # the full shape: the static variables are `(h, w)` here but are expanded to `(b, t, h, w)`
+        # inside the model, and the decoder constructs a batch before the history dimension is
+        # inserted.
+        spatial_shape = _consistent(
+            (tuple(v.shape[-2:]) for v in surf + static + atmos if v.dim() >= 2),
+            "spatial shape",
+            "surface-level, static and atmospheric variables",
+        )
+
+        # The history dimension is only present on fully shaped variables, so check it only where
+        # it exists.
+        _consistent(
+            [v.shape[1] for v in surf if v.dim() == 4]
+            + [v.shape[1] for v in atmos if v.dim() == 5],
+            "history size",
+            "surface-level and atmospheric variables",
+        )
+
+        if spatial_shape is not None:
+            self._check_lat_lon(*spatial_shape)
+
+    def _check_lat_lon(self, h: int, w: int) -> None:
+        """Check that the latitudes and longitudes describe an `h` by `w` grid."""
+        lat, lon = self.metadata.lat, self.metadata.lon
+
+        # :meth:`Metadata.__post_init__` has already checked that the latitudes and longitudes are
+        # either both vectors or both matrices.
+        if lat.dim() == 1:
+            if lat.shape[0] != h or lon.shape[0] != w:
+                raise ValueError(
+                    f"The latitudes and longitudes describe a grid of shape "
+                    f"{(lat.shape[0], lon.shape[0])}, but the variables have spatial shape "
+                    f"{(h, w)}."
+                )
+        elif tuple(lat.shape) != (h, w) or tuple(lon.shape) != (h, w):
+            raise ValueError(
+                f"The latitude and longitude matrices have shapes {tuple(lat.shape)} and "
+                f"{tuple(lon.shape)}, but the variables have spatial shape {(h, w)}."
+            )
 
     @property
     def spatial_shape(self) -> tuple[int, int]:
@@ -309,6 +355,25 @@ class Batch:
                 rollout_step=int(ds.rollout_step.values),
             ),
         )
+
+
+def _consistent(values: Iterable, what: str, of_what: str) -> object | None:
+    """Check that `values` are all equal.
+
+    Args:
+        values (iterable): Values to compare.
+        what (str): Description of the values, used in the error message.
+        of_what (str): Description of where the values came from, used in the error message.
+
+    Returns:
+        object or None: The common value, or `None` if `values` is empty.
+    """
+    unique = set(values)
+    if len(unique) > 1:
+        raise ValueError(
+            f"The {of_what} must all have the same {what}, but found {sorted(unique)}."
+        )
+    return unique.pop() if unique else None
 
 
 def _np(x: torch.Tensor) -> np.ndarray:

--- a/tests/test_batch.py
+++ b/tests/test_batch.py
@@ -1,12 +1,16 @@
 """Copyright (c) Microsoft Corporation. Licensed under the MIT license."""
 
+import dataclasses
+from datetime import datetime
 from pathlib import Path
 
 import numpy as np
+import pytest
+import torch
 
 from tests.conftest import SavedBatch
 
-from aurora import Batch
+from aurora import Batch, Metadata
 
 
 def test_interpolation(test_input_output: tuple[Batch, SavedBatch]) -> None:
@@ -57,3 +61,76 @@ def test_save_load(test_input_output: tuple[Batch, SavedBatch], tmp_path: Path) 
     assert batch.metadata.time == batch_loaded.metadata.time
     assert batch.metadata.atmos_levels == batch_loaded.metadata.atmos_levels
     assert batch.metadata.rollout_step == batch_loaded.metadata.rollout_step
+
+
+_LEVELS = (100, 250, 500, 850)
+
+
+def _metadata(n_lat: int = 17, n_lon: int = 32, n_levels: int = 4) -> Metadata:
+    return Metadata(
+        lat=torch.linspace(90, -90, n_lat),
+        lon=torch.linspace(0, 360, n_lon + 1)[:-1],
+        time=(datetime(2020, 6, 1, 12, 0),),
+        atmos_levels=_LEVELS[:n_levels],
+    )
+
+
+def _batch(metadata: Metadata | None = None) -> Batch:
+    return Batch(
+        surf_vars={"2t": torch.randn(1, 2, 17, 32)},
+        static_vars={"lsm": torch.randn(17, 32)},
+        atmos_vars={"z": torch.randn(1, 2, 4, 17, 32)},
+        metadata=metadata if metadata is not None else _metadata(),
+    )
+
+
+@pytest.mark.parametrize("n_lat, n_lon", [(9, 32), (17, 16), (18, 32), (17, 33)])
+def test_mismatching_lat_lon_and_spatial_shape(n_lat: int, n_lon: int) -> None:
+    # The encoder only asserts this. That assertion carries no message and is removed under
+    # `python -O`, so the mismatch reaches the caller as a bare `AssertionError` at best.
+    with pytest.raises(ValueError, match="describe a grid of shape"):
+        _batch(_metadata(n_lat=n_lat, n_lon=n_lon))
+
+
+def test_matrix_lat_lon_is_accepted() -> None:
+    metadata = _metadata()
+    metadata.lat = metadata.lat[:, None].expand(17, 32)
+    metadata.lon = metadata.lon[None, :].expand(17, 32)
+    assert _batch(metadata).spatial_shape == (17, 32)
+
+
+def test_mismatching_matrix_lat_lon() -> None:
+    metadata = _metadata(n_lat=18)
+    metadata.lat = metadata.lat[:, None].expand(18, 32)
+    metadata.lon = metadata.lon[None, :].expand(18, 32)
+    with pytest.raises(ValueError, match="latitude and longitude matrices"):
+        _batch(metadata)
+
+
+def test_inconsistent_spatial_shape_between_variables() -> None:
+    with pytest.raises(ValueError, match="same spatial shape"):
+        dataclasses.replace(_batch(), static_vars={"lsm": torch.randn(9, 32)})
+
+
+def test_inconsistent_history_between_variables() -> None:
+    with pytest.raises(ValueError, match="same history size"):
+        dataclasses.replace(_batch(), atmos_vars={"z": torch.randn(1, 3, 4, 17, 32)})
+
+
+def test_empty_variables_are_allowed() -> None:
+    # Running without atmospheric variables is suggested in #176, so an empty dictionary must not
+    # trip the validation.
+    batch = Batch(
+        surf_vars={"2t": torch.randn(1, 2, 17, 32)},
+        static_vars={"lsm": torch.randn(17, 32)},
+        atmos_vars={},
+        metadata=_metadata(),
+    )
+    assert batch.atmos_vars == {}
+
+
+def test_derived_batches_stay_valid(test_input_output: tuple[Batch, SavedBatch]) -> None:
+    # The operations that construct new batches must not trip the validation.
+    batch, _ = test_input_output
+    for derived in (batch.to("cpu"), batch.crop(4), batch.regrid(0.45)):
+        assert derived.spatial_shape == next(iter(derived.surf_vars.values())).shape[-2:]


### PR DESCRIPTION
Builds on #196, and should be merged after it.

#196 validates that `metadata.time` and `metadata.atmos_levels` match the data. This adds the
remaining shape invariants that `Batch` documents but does not enforce. There is no functional
overlap: nothing here touches `metadata.time` or `atmos_levels`.

### What it checks

1. Every surface-level, static and atmospheric variable describes the same grid.
2. The surface-level and atmospheric variables agree on the history dimension.
3. The latitudes and longitudes match that grid, in both the vector and the matrix form.

### Why these three

The latitudes and longitudes are already checked in `Aurora3DEncoder.forward`, but with

```python
assert lat.shape[0] == H and lon.shape[-1] == W
```

which carries no message, fires deep inside the forward pass rather than where the batch was
built, and is removed entirely under `python -O`. The other two currently surface as shape errors
from inside torch, for example `Sizes of tensors must match except in dimension 2`, which does not
tell the caller which variable is wrong.

Raising at construction, next to the existing latitude and longitude validation in
`Metadata.__post_init__`, points at the actual problem.

### Two implementation notes

The spatial shape is read from the last two dimensions rather than the full shape. The static
variables are `(h, w)` at the public API but `Aurora.forward` expands them to `(b, t, h, w)`, and
`Perceiver3DDecoder` constructs a `Batch` before the history dimension is inserted. Comparing full
shapes would reject both.

For the same reason the history dimension is only checked on variables that still have one, that
is surface-level variables with four dimensions and atmospheric variables with five.

### Empty variable dictionaries

An empty `surf_vars` or `atmos_vars` is left alone rather than treated as an error, since running
without atmospheric variables is something you suggested trying in #176. There is a test for it.

### Merge conflict, and how I would like to handle it

This creates `Batch.__post_init__`, and so does #196. They will conflict textually even though the
checks are disjoint. #196 is approved and should land first. Once it does, say the word and I will
rebase this onto it so the two sets of checks sit in one method. Happy to do that at any point,
including before you review, if that is easier.

### Tests

Added to `tests/test_batch.py`:

- latitudes or longitudes that do not match the grid raise, covering four combinations;
- matrix latitudes and longitudes are accepted, and mismatched matrices raise;
- variables that disagree with each other on the grid raise;
- variables that disagree on the history dimension raise;
- an empty `atmos_vars` is accepted;
- `to`, `crop` and `regrid` still produce valid batches.

Full suite passes apart from `test_aurora_small`, which fails for me at `0.04224444 / 276.22` on
unmodified `main` as well. That looks like the machine-dependent numerics in #169, so I am flagging
it rather than claiming it is related to this change. `ruff check` and `ruff format --check` are
clean.
